### PR TITLE
add labeler setting

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,8 @@
+version: 1
+labels:
+  - label: "feature"
+    branch: "^feat/.*"
+  - label: "bug"
+    branch: "^fix/.*"
+  - label: "chore"
+    branch: "^chore/.*"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,13 @@
+name: labeler
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: srvaroa/labeler@v0.6
+      env:
+        GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
## 概要
GitHub Actionsを用いた自動ラベリング機能を追加

## なぜこのPRが必要なのか
 - ラベルを付けると後々見直した時にバグ修正や機能追加の違いが分かりやすくなるため

## ブランチの命名規則

 - `feat/`を接頭辞とするブランチでPRを投げた場合
   - 新しい機能の追加
 - `fix/`を接頭辞とするブランチでPRを投げた場合
   - 既に存在する機能の修正
 - `chore/`を接頭辞とするブランチでPRを投げた場合
   - ドキュメント整理のような雑務