### PR TITLE
chore: update dependabot config to group npm updates and limit PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,4 +5,8 @@ updates:
   schedule:
     interval: daily
     time: "20:00"
-  open-pull-requests-limit: 10
+  open-pull-requests-limit: 1
+  groups:
+    npm-all:
+      patterns:
+        - "*"


### PR DESCRIPTION
## Summary

- Reduce `open-pull-requests-limit` from 10 to 1 to avoid PR noise
- Add `groups` config to bundle all npm dependency updates into a single PR

## Test plan

- [ ] Verify dependabot config is valid YAML
- [ ] Confirm next dependabot run creates a grouped PR for npm updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)