### PR TITLE
docs: VitePress 移行に合わせて README を更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,31 +1,32 @@
 # note
 
-TechBlog兼ポートフォリオです。
+[task4233.dev](https://task4233.dev/) のポートフォリオサイトです。
 
 
 ## Description
-記事にするほどではない。でも, メモとして残しておきたい。そんな時にVuePressを見つけました。
-markdown, TeXに対応しているので便利です。
+プロフィール / Publications / Employments / Awards 等を載せたシングルページのポートフォリオサイト。
 
 ## Features
 
-- [VuePressの1.x系](https://v1.vuepress.vuejs.org/)を利用
-- markdownおよびTeXの適応
-- GitHub Pagesへのデプロイ
-- CircleCIを用いた自動デプロイ
+- [VitePress 1.x](https://vitepress.dev/) を利用
+- GitHub Pages へのデプロイ
+- GitHub Actions を用いた master push 連動の自動デプロイ
 
 ## Requirement
-- \>= yarn ver 1.17.3
-- [package.json](https://github.com/task4233/note/blob/master/package.json)に必要パッケージは載っています。
+- Node `>=22.18 <23` (`package.json` の `engines` で指定)
+- yarn 4 (corepack 経由)
+- [package.json](https://github.com/task4233/note/blob/master/package.json) に必要パッケージは載っています。
 
 
 ## Installation
 ```bash
 git clone https://github.com/task4233/note/
-yarn install
-yarn src:dev
+cd note
+corepack enable
+corepack yarn install
+corepack yarn dev
 ```
 
 ## Author
 
-[@task4233](https://twitter.com/task4233)
+[@task4233](https://x.com/task4233)


### PR DESCRIPTION
## 概要

VuePress 1 → VitePress 移行 (#141) と GitHub Actions デプロイ新設 (#142) に合わせて README.md を最新の状態に更新する。

## なぜこのPRが必要なのか

PR #141 / #142 のマージで実装は VitePress 1.x + Actions デプロイに切り替わったが、README は VuePress 1.x / CircleCI 時代の記述のまま残っており、初見の人が「どの SSG で動いているか」「どうセットアップするか」を README から読み取れない状態になっていた。

## めも

更新内容:

- スタック表記: VuePress 1.x → VitePress 1.x
- 「TechBlog兼ポートフォリオ」→ 「ポートフォリオ」に統一（ブログ撤去済みのため）
- markdown/TeX 対応の言及を削除（ホームページのみで未使用）
- CI: CircleCI → GitHub Actions
- yarn 1.17.3 → yarn 4 (corepack 経由)
- Installation 手順を corepack ベースに更新
- Author の Twitter リンクを X (x.com) に修正

## Test plan

- [ ] README プレビューで意図通り表示される
- [ ] Installation 手順を素のディレクトリで実行して動く（差分の整合性確認）